### PR TITLE
Mark all peerDependencies as optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,29 @@
     "ramda": "^0.28.0",
     "rimraf": "^3.0.2"
   },
+  "peerDependenciesMeta": {
+    "@aws-sdk/client-s3": {
+      "optional": true
+    },
+    "@gideo-llc/backblaze-b2-upload-any": {
+      "optional": true
+    },
+    "@google-cloud/storage": {
+      "optional": true
+    },
+    "backblaze-b2": {
+      "optional": true
+    },
+    "glob": {
+      "optional": true
+    },
+    "ramda": {
+      "optional": true
+    },
+    "rimraf": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "slugify": "^1.3.6"
   },


### PR DESCRIPTION
Mark all peerDependencies as optional.

This helps avoid Yarn warnings like this:
```
➤ YN0000: ┌ Resolution step
➤ YN0002: │ project doesn't provide @gideo-llc/backblaze-b2-upload-any (p33f4b), requested by @ianatha/storage-abstraction
➤ YN0002: │ project doesn't provide @google-cloud/storage (peac85), requested by @ianatha/storage-abstraction
➤ YN0002: │ project doesn't provide backblaze-b2 (p4d281), requested by @ianatha/storage-abstraction
➤ YN0002: │ project doesn't provide glob (p73d9e), requested by @ianatha/storage-abstraction
➤ YN0002: │ project doesn't provide ramda (p957b8), requested by @ianatha/storage-abstraction
```